### PR TITLE
Fix: Removes help from commands

### DIFF
--- a/src/js/args/index.js
+++ b/src/js/args/index.js
@@ -14,7 +14,7 @@ const publicMethods = {
   parse,
   example,
   examples,
-  //showHelp,
+  showHelp,
 };
 
 export default function Args() {

--- a/src/js/components/Terminal/terminal-utils.js
+++ b/src/js/components/Terminal/terminal-utils.js
@@ -61,7 +61,7 @@ export function modCommands(commands) {
         parse = i =>
           cmd.parse(i, {
             name,
-            help: true,
+            help: false,
             version: false,
           });
         method = definition.method; // eslint-disable-line


### PR DESCRIPTION
#### Purpose
The help function is broken.

#### Approach
* Removes the help function for default commands